### PR TITLE
fix broken blank substitution for .cz domain count

### DIFF
--- a/grab-cznic-count
+++ b/grab-cznic-count
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-A=$(echo "$(date +%s) ";  wget -q -O - http://www.nic.cz/ | grep "DNSSEC</a>:" | tr " " "\n" | grep '<strong>' | cut -f2 -d\> | cut -f1 -d\< | sed 's/ //g' )
+A=$(echo "$(date +%s) ";  wget -q -O - http://www.nic.cz/ | grep "DNSSEC</a>:" | tr " " "\n" | grep '<strong>' | cut -f2 -d\> | cut -f1 -d\< | sed 's/[^0-9]//g' )
 echo $A
 


### PR DESCRIPTION
Graph on https://xs.powerdns.com/dnssec-nl-graph/ shows emtpy data points for .cz DNSSec delegations. It seems they have not only a blank in their number they report on their website.
So a sed 's/[^0-9]//g' should do the trick.
